### PR TITLE
Resolving build errors and reducing package requirements to whats needed.

### DIFF
--- a/hyprland-qt-support.spec
+++ b/hyprland-qt-support.spec
@@ -11,8 +11,8 @@ BuildRequires:	pkgconfig(Qt6Core)
 BuildRequires:	pkgconfig(Qt6Qml)
 BuildRequires:	pkgconfig(Qt6Quick)
 BuildRequires:	pkgconfig(Qt6QuickControls2)
+BuildRequires:	pkgconfig(hyprlang)
 
-BuildRequires:	pkgconfig(hyprland) >= 0.6.0
 BuildRequires:	pkgconfig(vulkan)
 
 

--- a/hyprland-qt-support.spec
+++ b/hyprland-qt-support.spec
@@ -7,13 +7,10 @@ URL:		https://hyprland.org/
 License:	BSD-3-Clause
 Group:		Hyprland
 
-BuildRequires:	pkgconfig(Qt6Core)
 BuildRequires:	pkgconfig(Qt6Qml)
 BuildRequires:	pkgconfig(Qt6Quick)
 BuildRequires:	pkgconfig(Qt6QuickControls2)
 BuildRequires:	pkgconfig(hyprlang)
-
-BuildRequires:	pkgconfig(vulkan)
 
 
 BuildSystem:	cmake


### PR DESCRIPTION
Qt6core, hyprland, and vulkan requirements are not necessary for the building of the package when building from fresh environment.